### PR TITLE
Switch to Inkscape for generating PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ What you'll get is, for each input file, a pair of font-embedded PDFs in
 
 ## Prerequisites
 
-The PDF generation relies on [librsvg](https://github.com/GNOME/librsvg)'s
-`rsvg-convert` being on your path.
+The PDF generation relies on [Inkscape](https://inkscape.org/)'s `inkscape`
+binary being on your path.
 
-To install it on a Mac with [homebrew](https://brew.sh), run `brew install
-librsvg`.
+To install it on a Mac with [Homebrew](https://brew.sh) and
+[Homebrew Cask](https://caskroom.github.io/), run
+`brew cask install xquartz inkscape`.
 
 ## TODO
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function (options, cb) {
   var inputDir = options.inputDir || 'input'
   var tmpDir = options.tmpDir || 'tmp'
   var outputDir = options.outputDir || 'output'
-  var convertTemplate = options.command || 'rsvg-convert -f pdf -o {{{pdf}}} {{{svg}}}'
+  var convertTemplate = options.command || 'inkscape {{{svg}}} --without-gui --export-pdf={{{pdf}}}'
 
   asink.mapValues(TEMPLATES, function (path, key, cb) {
     fs.readFile(path, 'utf8', cb)


### PR DESCRIPTION
librsvg mangles the text rendering for custom fonts. Inkscape doesn't.

For example (librsvg on the left, Inkscape on the right):
<img width="899" alt="screen shot 2018-04-27 at 11 48 28" src="https://user-images.githubusercontent.com/108518/39371916-075c39c8-4a11-11e8-839d-8204056ed440.png">
